### PR TITLE
info message: calling maven, and the dependency on jsonld-java

### DIFF
--- a/jsonldplayground
+++ b/jsonldplayground
@@ -7,6 +7,7 @@
 # run ./jsonldplayground for the usage
 
 if [ ! -d "target/appassembler/bin" ]; then
+    echo -e "Building with maven... (This could fail if you haven't previously run 'mvn install' on jsonld-java)\n">&2
     mvn -quiet clean install -DskipTests
 fi
 


### PR DESCRIPTION
I tried the playground before building jsonld-java. It doesn't seem strange to me to try it in this order. Although I figured it out quickly, the script failed with an error message from maven that many could find unhelpful, so it might be good to explicitly state that jsonld-java needs to be installed first.